### PR TITLE
feat: Use GitHub Action & Issue labels for sending admission letters (#666)

### DIFF
--- a/.github/configs/label-commenter-config.yml
+++ b/.github/configs/label-commenter-config.yml
@@ -1,0 +1,25 @@
+# .github/configs/label-commenter-config.yml
+
+labels:
+  - name: 'accepted'
+    labeled:
+      issue:
+        body: |
+          Hi,
+          Congratulations! Your application has been accepted and the offer has been sent to your mail. Please confirm the offer or the invitation within 7 days.
+
+          Regards,
+          Home University
+
+  - name: 'rejected'
+    labeled:
+      issue:
+        body: |
+          Hi,
+
+          The admission committee has concluded its evaluation of Early Decision applicants to Home University. Unfortunately, we are unable to offer you a place in our class. Since Home University was your top choice, we understand this news is very disappointing.
+
+          The admission committee appreciates the time and effort you put into applying to Home University. We wish you every success as you pursue your education.
+
+          Regards,
+          Admission Committee, Home University

--- a/.github/workflow/label-commenter.yml
+++ b/.github/workflow/label-commenter.yml
@@ -1,0 +1,18 @@
+name: Label Commenter
+
+on:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+      
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .github/configs/label-commenter-config.yml


### PR DESCRIPTION
This PR adds a GitHub Action for automatically sending admission letters depending on the labels (accepted/rejected).

resolve: #666